### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.4"
 edition = "2018"
 description = "A Rust client for interacting with the Exa/Metaphor systems API"
 license = "MIT"  
-
+repository = "https://github.com/maishathasin/exa-rs"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.